### PR TITLE
Display entity data in a more intuitive way (#116)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,10 +12,12 @@
 - Policy display on entity table (#118)
 - Mongo auth (#153)
 - Custom text home page (#125)
+- Entity visualization (#116)
 
 ### Bug fixes
 
 - Resource types on entities page
+- Datepicker fix for MUIx 6.0.2
 
 ### Documentation
 

--- a/documentation/stories/entity/display.jsx
+++ b/documentation/stories/entity/display.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import Grid from '@mui/material/Grid';
-import EntityForm from '../../../src/components/entity/entityForm';
+import EntityDisplay from '../../../src/components/entity/entityDisplay';
 import { BrowserRouter } from 'react-router-dom';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { orange } from '@mui/material/colors';
@@ -17,36 +17,24 @@ const theme = createTheme({
   }
 });
 
-export const Form = ({
+export const Display = ({
   title,
   close,
-  action,
-  env,
   data,
-  getTheEntities,
   types,
-  services,
-  GeTenantData,
-  entityEndpoint,
-  view
+  setView
 }) => {
   return (
     <SnackbarProvider maxSnack={5}>
       <ThemeProvider theme={theme}>
         <BrowserRouter>
           <Grid>
-            <EntityForm
+            <EntityDisplay
               title={title}
               close={close}
-              action={action}
-              env={env}
               data={data}
-              getTheEntities={getTheEntities}
               types={types}
-              services={services}
-              GeTenantData={GeTenantData}
-              entityEndpoint={entityEndpoint}
-              view={view}
+              setView={setView}
             />
           </Grid>
         </BrowserRouter>
@@ -55,7 +43,7 @@ export const Form = ({
   );
 };
 
-Form.propTypes = {
+Display.propTypes = {
   /**
    * The Titile that is going to be displayed inside the form
    */
@@ -69,49 +57,19 @@ Form.propTypes = {
    */
   data: PropTypes.object,
   /**
-   * The form action
-   */
-  action: PropTypes.oneOf(['create', 'modify']),
-  /**
-   * the config file passed
-   */
-  env: PropTypes.object,
-  /**
-   * The function to call to get the entities related to the Tenant
-   */
-  getTheEntities: PropTypes.func,
-  /**
    * the array of object with all of the attributes types
    */
   types: PropTypes.arrayOf(PropTypes.object),
   /**
-   * the array of object with all of the services
+   * The function to switch to the edit mode of the form
    */
-  services: PropTypes.arrayOf(PropTypes.object),
-  /**
-   * The function to get the Tenant data after a save
-   */
-  GeTenantData: PropTypes.func,
-  /**
-   * The defined enpoint of the entity
-   */
-  entityEndpoint: PropTypes.string,
-  /**
-   * The function to go back to the view mode (only if action is 'modify')
-   */
-  view: PropTypes.func
+  setView: PropTypes.func
 };
 
-Form.defaultProps = {
+Display.defaultProps = {
   title: 'Title',
   close: () => {},
-  action: null,
-  env: {},
   data: {},
-  getTheEntities: () => {},
   types: [],
-  services: [],
-  GeTenantData: () => {},
-  entityEndpoint: '',
-  view: () => {}
+  setView: () => {}
 };

--- a/documentation/stories/entity/display.jsx
+++ b/documentation/stories/entity/display.jsx
@@ -17,25 +17,13 @@ const theme = createTheme({
   }
 });
 
-export const Display = ({
-  title,
-  close,
-  data,
-  types,
-  setView
-}) => {
+export const Display = ({ title, close, data, types, setView }) => {
   return (
     <SnackbarProvider maxSnack={5}>
       <ThemeProvider theme={theme}>
         <BrowserRouter>
           <Grid>
-            <EntityDisplay
-              title={title}
-              close={close}
-              data={data}
-              types={types}
-              setView={setView}
-            />
+            <EntityDisplay title={title} close={close} data={data} types={types} setView={setView} />
           </Grid>
         </BrowserRouter>
       </ThemeProvider>

--- a/documentation/stories/entity/display.stories.jsx
+++ b/documentation/stories/entity/display.stories.jsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { Display } from './display';
+import { Title, Subtitle, Description, ArgsTable, PRIMARY_STORY } from '@storybook/addon-docs';
+
+// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+export default {
+  title: 'Entity/Form/DisplayData',
+  component: Display,
+  // More on argTypes: https://storybook.js.org/docs/react/api/argtypes
+  argTypes: {
+    title: {
+      control: false
+    },
+    close: {
+      control: false
+    },
+    data: {
+      control: false
+    },
+    types: {
+      control: false
+    },
+    setView: {
+      control: false
+    }
+  },
+  parameters: {
+    docs: {
+      page: () => (
+        <>
+          <Title>Entity Display:</Title>
+          <Subtitle>Description:</Subtitle>
+          <Description>The visualization of every element chainde to the entity </Description>
+          <Description>
+            The component is returning a more simple data visualization for the entity and the possibility to switch to the edit form.
+          </Description>
+          <Subtitle>API Documentation:</Subtitle>
+          <Description>The entity display component is inside entity/entityDisplay.js :</Description>
+
+          <ArgsTable story={PRIMARY_STORY} />
+        </>
+      )
+    }
+  }
+};
+
+// More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
+const Template = (args) => <Display {...args} />;
+
+export const ShowData = Template.bind({});
+ShowData.args = {
+  title: 'Edit',
+  close: () => {},
+  data:   {
+    "id": "urn:ngsi-ld:AirQualityObserved:Tenant1",
+    "type": "AirQualityObserved",
+    "awawdawda": {
+        "type": "Boolean",
+        "value": true,
+        "metadata": {}
+    },
+    "e": {
+        "type": "geo:json",
+        "value": {
+            "type": "Point",
+            "coordinates": [
+                47.374539757,
+                8.545657396
+            ]
+        },
+        "metadata": {}
+    },
+    "eeeee": {
+        "type": "Text",
+        "value": "aaaaaaaah",
+        "metadata": {}
+    },
+    "ffff": {
+        "type": "StructuredValue",
+        "value": {
+            "a": 52
+        },
+        "metadata": {}
+    },
+    "s": {
+        "type": "Number",
+        "value": 23,
+        "metadata": {}
+    },
+    "temperature": {
+        "type": "DateTime",
+        "value": "2023-03-01T17:25:00.000Z",
+        "metadata": {}
+    },
+    "dateCreated": {
+        "type": "DateTime",
+        "value": "2023-03-28T09:00:31.832Z",
+        "metadata": {}
+    },
+    "dateModified": {
+        "type": "DateTime",
+        "value": "2023-03-30T15:50:55.454Z",
+        "metadata": {}
+    }
+},
+  types: [
+    {
+      attrs: {
+        temperature: {
+          types: ['Number']
+        },
+
+        test: {
+          types: ['geo:json']
+        }
+      },
+      count: 1,
+      type: 'AirQualityObserved'
+    }
+  ],
+  setView: () => {}
+};
+

--- a/documentation/stories/entity/display.stories.jsx
+++ b/documentation/stories/entity/display.stories.jsx
@@ -32,7 +32,8 @@ export default {
           <Subtitle>Description:</Subtitle>
           <Description>The visualization of every element chainde to the entity </Description>
           <Description>
-            The component is returning a more simple data visualization for the entity and the possibility to switch to the edit form.
+            The component is returning a more simple data visualization for the entity and the possibility to switch to
+            the edit form.
           </Description>
           <Subtitle>API Documentation:</Subtitle>
           <Description>The entity display component is inside entity/entityDisplay.js :</Description>
@@ -51,58 +52,55 @@ export const ShowData = Template.bind({});
 ShowData.args = {
   title: 'Edit',
   close: () => {},
-  data:   {
-    "id": "urn:ngsi-ld:AirQualityObserved:Tenant1",
-    "type": "AirQualityObserved",
-    "awawdawda": {
-        "type": "Boolean",
-        "value": true,
-        "metadata": {}
+  data: {
+    id: 'urn:ngsi-ld:AirQualityObserved:Tenant1',
+    type: 'AirQualityObserved',
+    awawdawda: {
+      type: 'Boolean',
+      value: true,
+      metadata: {}
     },
-    "e": {
-        "type": "geo:json",
-        "value": {
-            "type": "Point",
-            "coordinates": [
-                47.374539757,
-                8.545657396
-            ]
-        },
-        "metadata": {}
+    e: {
+      type: 'geo:json',
+      value: {
+        type: 'Point',
+        coordinates: [47.374539757, 8.545657396]
+      },
+      metadata: {}
     },
-    "eeeee": {
-        "type": "Text",
-        "value": "aaaaaaaah",
-        "metadata": {}
+    eeeee: {
+      type: 'Text',
+      value: 'aaaaaaaah',
+      metadata: {}
     },
-    "ffff": {
-        "type": "StructuredValue",
-        "value": {
-            "a": 52
-        },
-        "metadata": {}
+    ffff: {
+      type: 'StructuredValue',
+      value: {
+        a: 52
+      },
+      metadata: {}
     },
-    "s": {
-        "type": "Number",
-        "value": 23,
-        "metadata": {}
+    s: {
+      type: 'Number',
+      value: 23,
+      metadata: {}
     },
-    "temperature": {
-        "type": "DateTime",
-        "value": "2023-03-01T17:25:00.000Z",
-        "metadata": {}
+    temperature: {
+      type: 'DateTime',
+      value: '2023-03-01T17:25:00.000Z',
+      metadata: {}
     },
-    "dateCreated": {
-        "type": "DateTime",
-        "value": "2023-03-28T09:00:31.832Z",
-        "metadata": {}
+    dateCreated: {
+      type: 'DateTime',
+      value: '2023-03-28T09:00:31.832Z',
+      metadata: {}
     },
-    "dateModified": {
-        "type": "DateTime",
-        "value": "2023-03-30T15:50:55.454Z",
-        "metadata": {}
+    dateModified: {
+      type: 'DateTime',
+      value: '2023-03-30T15:50:55.454Z',
+      metadata: {}
     }
-},
+  },
   types: [
     {
       attrs: {
@@ -120,4 +118,3 @@ ShowData.args = {
   ],
   setView: () => {}
 };
-

--- a/documentation/stories/entity/form.jsx
+++ b/documentation/stories/entity/form.jsx
@@ -27,7 +27,8 @@ export const Form = ({
   types,
   services,
   GeTenantData,
-  entityEndpoint
+  entityEndpoint,
+  view
 }) => {
   return (
     <SnackbarProvider maxSnack={5}>
@@ -45,6 +46,7 @@ export const Form = ({
               services={services}
               GeTenantData={GeTenantData}
               entityEndpoint={entityEndpoint}
+              view={view}
             />
           </Grid>
         </BrowserRouter>
@@ -93,7 +95,11 @@ Form.propTypes = {
   /**
    * The defined enpoint of the entity
    */
-  entityEndpoint: PropTypes.string
+  entityEndpoint: PropTypes.string,
+  /**
+   * The function to go back to the view mode
+   */
+  view: PropTypes.func
 };
 
 Form.defaultProps = {
@@ -106,5 +112,6 @@ Form.defaultProps = {
   types: [],
   services: [],
   GeTenantData: () => {},
-  entityEndpoint: ''
+  entityEndpoint: '',
+  view: () => {}
 };

--- a/documentation/stories/entity/form.stories.jsx
+++ b/documentation/stories/entity/form.stories.jsx
@@ -37,6 +37,9 @@ export default {
     },
     entityEndpoint: {
       control: false
+    },
+    view: {
+      control: false
     }
   },
   parameters: {

--- a/documentation/stories/entity/form.stories.jsx
+++ b/documentation/stories/entity/form.stories.jsx
@@ -105,7 +105,7 @@ Edit.args = {
     }
   ],
   GeTenantData: () => {},
-   view: () => {},
+  view: () => {},
   entityEndpoint: 'http://localhost:1026/v2/entities?attrs=dateCreated,dateModified,*&options=count'
 };
 
@@ -148,6 +148,6 @@ Create.args = {
     }
   ],
   GeTenantData: () => {},
-   view: () => {},
+  view: () => {},
   entityEndpoint: 'http://localhost:1026/v2/entities?attrs=dateCreated,dateModified,*&options=count'
 };

--- a/documentation/stories/entity/form.stories.jsx
+++ b/documentation/stories/entity/form.stories.jsx
@@ -105,6 +105,7 @@ Edit.args = {
     }
   ],
   GeTenantData: () => {},
+   view: () => {},
   entityEndpoint: 'http://localhost:1026/v2/entities?attrs=dateCreated,dateModified,*&options=count'
 };
 
@@ -147,5 +148,6 @@ Create.args = {
     }
   ],
   GeTenantData: () => {},
+   view: () => {},
   entityEndpoint: 'http://localhost:1026/v2/entities?attrs=dateCreated,dateModified,*&options=count'
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@mui/material": "^5.11.0",
         "@mui/system": "^5.10.15",
         "@mui/utils": "^5.10.15",
-        "@mui/x-date-pickers": "^6.0.1",
+        "@mui/x-date-pickers": "^6.0.2",
         "@testing-library/jest-dom": "^5.16.2",
         "axios": "^1.3.4",
         "colord": "^2.9.2",
@@ -4408,11 +4408,11 @@
       }
     },
     "node_modules/@mui/x-date-pickers": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-6.0.1.tgz",
-      "integrity": "sha512-eZ3uTWp2uA08h4IULoqI7rkP16ltzZH0kSdZdvLCvaa4ix1ZP5zGcvt8CdtxM+NFWjRS7fGWPOgOoScGw9lKLQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-6.0.3.tgz",
+      "integrity": "sha512-TgKfWf47WiNzSAY3C8R+FQ2grtVveoS3WCtLf6E1I/O2adxruxXA+AFiIRVnfv8QX9QFLNayTKoaVUISg/PcXQ==",
       "dependencies": {
-        "@babel/runtime": "^7.20.13",
+        "@babel/runtime": "^7.21.0",
         "@date-io/core": "^2.16.0",
         "@date-io/date-fns": "^2.16.0",
         "@date-io/date-fns-jalali": "^2.16.0",
@@ -4421,7 +4421,7 @@
         "@date-io/jalaali": "^2.16.1",
         "@date-io/luxon": "^2.16.1",
         "@date-io/moment": "^2.16.1",
-        "@mui/utils": "^5.11.7",
+        "@mui/utils": "^5.11.13",
         "@types/react-transition-group": "^4.4.5",
         "clsx": "^1.2.1",
         "prop-types": "^15.8.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@mui/material": "^5.11.0",
     "@mui/system": "^5.10.15",
     "@mui/utils": "^5.10.15",
-    "@mui/x-date-pickers": "^6.0.1",
+    "@mui/x-date-pickers": "^6.0.2",
     "@testing-library/jest-dom": "^5.16.2",
     "axios": "^1.3.4",
     "colord": "^2.9.2",

--- a/src/components/entity/entityDisplay.js
+++ b/src/components/entity/entityDisplay.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
-import DeleteIcon from '@mui/icons-material/Delete';
 import { styled } from '@mui/material/styles';
 import DialogContent from '@mui/material/DialogContent';
 import AppBar from '@mui/material/AppBar';
@@ -15,28 +14,38 @@ import FormControl from '@mui/material/FormControl';
 import OutlinedInput from '@mui/material/OutlinedInput';
 import { InputLabel } from '@mui/material';
 import Select from '@mui/material/Select';
-import FormHelperText from '@mui/material/FormHelperText';
 import useNotification from '../shared/messages/alerts';
 import { Trans } from 'react-i18next';
-import axios from 'axios';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import InputAdornment from '@mui/material/InputAdornment';
 import 'dayjs/locale/en';
 import 'dayjs/locale/it';
+import dayjs from 'dayjs';
 import AccessTimeIcon from '@mui/icons-material/AccessTime';
-import ClearIcon from '@mui/icons-material/Clear';
 import { MobileDateTimePicker } from '@mui/x-date-pickers/MobileDateTimePicker';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Switch from '@mui/material/Switch';
-import Tooltip from '@mui/material/Tooltip';
-import AddIcon from '@mui/icons-material/Add';
-import JsonEdit from './jsonEditor';
 import MapEdit from './map/mapEditor';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
-import Autocomplete from '@mui/material/Autocomplete';
-import Chip from '@mui/material/Chip';
+import { darken } from '@mui/material';
+import { lighten } from '@mui/material';
+import PinIcon from '@mui/icons-material/Pin';
+import TextsmsIcon from '@mui/icons-material/Textsms';
+import List from '@mui/material/List';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import Collapse from '@mui/material/Collapse';
+import ExpandLess from '@mui/icons-material/ExpandLess';
+import ExpandMore from '@mui/icons-material/ExpandMore';
+import AutoFixNormalIcon from '@mui/icons-material/AutoFixNormal';
+import VanillaJSONEditor from '../shared/vanillaJsonEditor';
+import ListItemText from '@mui/material/ListItemText';
+import { MapContainer, TileLayer, useMap, GeoJSON } from 'react-leaflet';
+import 'leaflet/dist/leaflet.css';
+import L from 'leaflet';
+import icon from './map/constants';
 
 const CustomDialogTitle = styled(AppBar)({
   position: 'relative',
@@ -48,6 +57,7 @@ const CustomSwitch = styled(Switch)(({ theme }) => ({
   padding: 8,
   '& .MuiSwitch-track': {
     borderRadius: 22 / 2,
+    opacity: '0.3 !important',
     '&:before, &:after': {
       content: '""',
       position: 'absolute',
@@ -77,6 +87,35 @@ const CustomSwitch = styled(Switch)(({ theme }) => ({
   }
 }));
 
+const DisplayCollapse = ({ component, icon }) => {
+  const theme = useTheme();
+  const [open, setOpen] = React.useState(false);
+
+  const handleClick = () => {
+    setOpen(!open);
+  };
+
+  return (
+    <List sx={{ width: '100%' }}>
+      <ListItemButton
+        onClick={handleClick}
+        sx={{ background: lighten(theme.palette.primary.main, 0.55), borderRadius: 3 }}
+      >
+        <ListItemIcon>{icon}</ListItemIcon>
+        <ListItemText primary="" />
+        {open ? (
+          <ExpandLess sx={{ color: theme.palette.getContrastText(theme.palette.primary.main) }} />
+        ) : (
+          <ExpandMore sx={{ color: theme.palette.getContrastText(theme.palette.primary.main) }} />
+        )}
+      </ListItemButton>
+      <Collapse in={open} timeout="auto" unmountOnExit>
+        <DialogContent sx={{ minHeight: '200px' }}>{component}</DialogContent>
+      </Collapse>
+    </List>
+  );
+};
+
 export default function EntityDisplay({
   title,
   close,
@@ -89,7 +128,8 @@ export default function EntityDisplay({
   GeTenantData,
   entityEndpoint
 }) {
-    const action="modify"
+  const theme = useTheme();
+  const isResponsive = useMediaQuery(theme.breakpoints.down('sm'));
   const getAttributesNames = (types) => {
     let map = [];
     for (let type of types) {
@@ -113,57 +153,63 @@ export default function EntityDisplay({
     { text: <Trans>entity.form.selectType.json</Trans>, id: 'StructuredValue' },
     { text: <Trans>entity.form.selectType.map</Trans>, id: 'geo:json' }
   ];
-  const [service, setService] = React.useState('');
-  const [id, setId] = React.useState('');
   //Type
   const [type, setType] = React.useState([]);
 
   const [attributesMap, setAttributesMap] = React.useState([]);
   const createAttributesMap = () => {
-      let map = [];
-      const attributes = Object.getOwnPropertyNames(data)
-        .filter((value) => attributeNames.includes(value))
-        .filter(function (e, i, c) {
-          return c.indexOf(e) === i;
-        });
-      for (let attribute of attributes) {
-        map.push({ name: attribute, type: data[attribute].type, value: data[attribute].value });
-      }
-      setAttributesMap(map);
-      return 0;
+    let map = [];
+    const attributes = Object.getOwnPropertyNames(data)
+      .filter((value) => attributeNames.includes(value))
+      .filter(function (e, i, c) {
+        return c.indexOf(e) === i;
+      });
+    for (let attribute of attributes) {
+      map.push({ name: attribute, type: data[attribute].type, value: data[attribute].value });
+    }
+    setAttributesMap(map);
+    return 0;
   };
   React.useEffect(() => {
     createAttributesMap();
   }, []);
-  const addEntities = () => {
-    setAttributesMap([...[{ name: '', type: 'Number', value: '' }], ...attributesMap]);
-  };
-  const removeEntities = (index) => {
-    const newArray = attributesMap;
-    newArray.splice(index, 1);
-    setAttributesMap([...[], ...newArray]);
-  };
-  const handleAttributeName = (value, index) => {
-    const newArray = attributesMap;
-    newArray[Number(index)].name = value;
-    setAttributesMap([...[], ...newArray]);
-  };
-  const handleAttributeType = (value, index) => {
-    const newArray = attributesMap;
-    newArray[Number(index)].type = value;
-    newArray[Number(index)].value = '';
-    setAttributesMap([...[], ...newArray]);
-  };
-  const handlePropagation = (e) => {
-    e.stopPropagation();
+
+  const returnCordinates = (attribute) => {
+    switch (true) {
+      //for a missed or default value
+      case attribute.value === '':
+        return [47.373878, 8.545094];
+      //for a JSON that has multiple features but only one coordinate
+      case typeof attribute.value.length !== 'undefined' && typeof attribute.value[0].coordinates[0] === 'number':
+        return attribute.value[0].coordinates;
+      //for a JSON that has multiple features and multiple coordinates
+      case typeof attribute.value.length !== 'undefined' && typeof attribute.value[0].coordinates !== 'number':
+        return attribute.value[0].coordinates[0];
+      //for a JSON that has a single feature and only one coordinate
+      case typeof attribute.value.length === 'undefined' && typeof attribute.value.coordinates[0] === 'number':
+        return attribute.value.coordinates;
+      //for a JSON that has a single feature but multiple coordinates
+      case typeof attribute.value.length === 'undefined' && typeof attribute.value.coordinates !== 'number':
+        return attribute.value.coordinates[0];
+      //default
+      default:
+        return [47.373878, 8.545094];
+    }
   };
   const attributeTypeForm = (attribute, index) => {
     switch (attribute.type !== '' && typeof attribute.type !== 'undefined' && attribute.type !== null) {
       case attribute.type === 'Number':
         return (
-          <Grid item xs={12} sm={12} md={4} lg={4} xl={4}>
+          <Grid item xs={12} sm={12} md={10} lg={10} xl={10}>
             <TextField
-             disabled
+              disabled
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <PinIcon sx={{ color: darken(theme.palette.secondary.main, index / 10) }}></PinIcon>
+                  </InputAdornment>
+                )
+              }}
               id={'Number' + index}
               variant="outlined"
               key={'Number' + index}
@@ -177,7 +223,7 @@ export default function EntityDisplay({
         );
       case attribute.type === 'DateTime':
         return (
-          <Grid item xs={12} sm={12} md={4} lg={4} xl={4}>
+          <Grid item xs={12} sm={12} md={10} lg={10} xl={10}>
             <LocalizationProvider
               dateAdapter={AdapterDayjs}
               adapterLocale={Intl.NumberFormat().resolvedOptions().locale}
@@ -185,114 +231,218 @@ export default function EntityDisplay({
               <MobileDateTimePicker
                 id={'dateInput' + index}
                 key={'dateInput' + index}
+                disabled
                 showToolbar={false}
-                value={attribute.value === '' ? new Date() : attribute.value}
+                value={attribute.value === '' ? dayjs() : dayjs(attribute.value)}
                 onChange={(newValue) => {
                   const newArray = attributesMap;
                   newArray[Number(index)].value = newValue;
                   setAttributesMap([...[], ...newArray]);
                 }}
-                renderInput={(params) => (
-                  <TextField
-                    {...params}
-                    InputProps={{
-                      endAdornment: (
-                        <InputAdornment position="end" onClick={handlePropagation}>
-                          <ClearIcon
-                            color="secondary"
-                            onClick={() => {
-                              const newArray = attributesMap;
-                              newArray[Number(index)].value = null;
-                              setAttributesMap([...[], ...newArray]);
-                            }}
-                            sx={{ '&:hover': { cursor: 'pointer' } }}
-                          />
-                        </InputAdornment>
-                      ),
+                slotProps={{
+                  field: {
+                    InputProps: {
                       startAdornment: (
                         <InputAdornment position="start">
-                          <AccessTimeIcon color="secondary"></AccessTimeIcon>
+                          <AccessTimeIcon
+                            sx={{ color: darken(theme.palette.secondary.main, index / 10) }}
+                          ></AccessTimeIcon>
                         </InputAdornment>
                       )
-                    }}
-                    error={errorCases(attribute.value)}
-                    sx={{
-                      width: '100%'
-                    }}
-                  />
-                )}
+                    }
+                  }
+                }}
+                error={errorCases(attribute.value)}
+                sx={{
+                  width: '100%'
+                }}
               />
             </LocalizationProvider>
           </Grid>
         );
       case attribute.type === 'Boolean':
         return (
-          <Grid item xs={12} sm={12} md={4} lg={4} xl={4}>
+          <Grid item xs={12} sm={12} md={10} lg={10} xl={10}>
             <Grid container direction="row" justifyContent="center" alignItems="center" spacing={0}>
-              <FormControlLabel
-                key={'switch' + index}
-                id={'switch' + index}
-                control={
-                  <CustomSwitch
-                    defaultChecked
-                    onChange={(event) => {
-                      const newArray = attributesMap;
-                      newArray[Number(index)].value = event.target.checked;
-                      setAttributesMap([...[], ...newArray]);
-                    }}
-                  />
-                }
-              />
+              <FormControl component="fieldset" variant="standard">
+                <FormControlLabel
+                  key={'switch' + index}
+                  id={'switch' + index}
+                  control={<CustomSwitch defaultChecked={attribute.value} color="info" disabled />}
+                />
+              </FormControl>
             </Grid>
           </Grid>
         );
       case attribute.type === 'Text':
         return (
-          <Grid item xs={12} sm={12} md={4} lg={4} xl={4}>
+          <Grid item xs={12} sm={12} md={10} lg={10} xl={10}>
             <TextField
               id="Text"
+              disabled
               variant="outlined"
-              value={attribute.value}
-              onChange={(event) => {
-                const newArray = attributesMap;
-                newArray[Number(index)].value = event.target.value;
-                setAttributesMap([...[], ...newArray]);
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <TextsmsIcon sx={{ color: darken(theme.palette.secondary.main, index / 10) }}></TextsmsIcon>
+                  </InputAdornment>
+                )
               }}
+              value={attribute.value}
               sx={{
                 width: '100%'
               }}
-              error={errorCases(attribute.value)}
             />
           </Grid>
         );
       case attribute.type === 'StructuredValue':
         return (
-          <Grid item xs={12} sm={12} md={4} lg={4} xl={4}>
-            <JsonEdit
-              attribute={attribute}
-              attributesMap={attributesMap}
-              setAttributesMap={setAttributesMap}
-              index={index}
-            ></JsonEdit>
+          <Grid item xs={12} sm={12} md={10} lg={10} xl={10}>
+            <DisplayCollapse
+              key={'json' + index}
+              icon={
+                <AutoFixNormalIcon
+                  sx={{ color: theme.palette.getContrastText(theme.palette.primary.main) }}
+                ></AutoFixNormalIcon>
+              }
+              component={
+                <Grid container maxWidth="xl" direction="row" justifyContent="center" alignItems="center">
+                  <Grid item xs={12} sm={12} md={12} lg={12} xl={12}>
+                    <VanillaJSONEditor
+                      content={
+                        attribute.value !== ''
+                          ? {
+                              json: attribute.value,
+                              text: undefined
+                            }
+                          : {
+                              json: {},
+                              text: undefined
+                            }
+                      }
+                      readOnly={true}
+                    />
+                  </Grid>
+                </Grid>
+              }
+            />
           </Grid>
         );
       case attribute.type === 'geo:json':
         return (
-          <Grid item xs={12} sm={12} md={4} lg={4} xl={4}>
-            <MapEdit
-              env={env}
-              attribute={attribute}
-              attributesMap={attributesMap}
-              setAttributesMap={setAttributesMap}
-              index={index}
-            ></MapEdit>
+          <Grid item xs={12} sm={12} md={10} lg={10} xl={10}>
+            <DisplayCollapse
+              key={'map' + index}
+              icon={
+                <AutoFixNormalIcon
+                  sx={{ color: theme.palette.getContrastText(theme.palette.primary.main) }}
+                ></AutoFixNormalIcon>
+              }
+              component={
+                <Grid container maxWidth="xl" direction="row" justifyContent="center" alignItems="center">
+                  <Grid item xs={12} sm={12} md={12} lg={12} xl={12}>
+                    <MapContainer
+                      zoom={18}
+                      center={returnCordinates(attribute)}
+                      style={{ height: '25vh', zIndex: 0 }}
+                      scrollWheelZoom={true}
+                    >
+                      <TileLayer
+                        attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+                        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                      />
+                      <GeoJSON
+                        key="ID"
+                        data={{
+                          type: 'FeatureCollection',
+                          features: [
+                            {
+                              type: 'Feature',
+                              id: '37',
+                              properties: { name: 'North Carolina', density: 198.2 },
+                              geometry: {
+                                type: 'Polygon',
+                                coordinates: [
+                                  [
+                                    [-80.978661, 36.562108],
+                                    [-80.294043, 36.545677],
+                                    [-79.510841, 36.5402],
+                                    [-75.868676, 36.551154],
+                                    [-75.75366, 36.151337],
+                                    [-76.032984, 36.189676],
+                                    [-76.071322, 36.140383],
+                                    [-76.410893, 36.080137],
+                                    [-76.460185, 36.025367],
+                                    [-76.68474, 36.008937],
+                                    [-76.673786, 35.937736],
+                                    [-76.399939, 35.987029],
+                                    [-76.3616, 35.943213],
+                                    [-76.060368, 35.992506],
+                                    [-75.961783, 35.899398],
+                                    [-75.781044, 35.937736],
+                                    [-75.715321, 35.696751],
+                                    [-75.775568, 35.581735],
+                                    [-75.89606, 35.570781],
+                                    [-76.147999, 35.324319],
+                                    [-76.482093, 35.313365],
+                                    [-76.536862, 35.14358],
+                                    [-76.394462, 34.973795],
+                                    [-76.279446, 34.940933],
+                                    [-76.493047, 34.661609],
+                                    [-76.673786, 34.694471],
+                                    [-76.991448, 34.667086],
+                                    [-77.210526, 34.60684],
+                                    [-77.555573, 34.415147],
+                                    [-77.82942, 34.163208],
+                                    [-77.971821, 33.845545],
+                                    [-78.179944, 33.916745],
+                                    [-78.541422, 33.851022],
+                                    [-79.675149, 34.80401],
+                                    [-80.797922, 34.820441],
+                                    [-80.781491, 34.935456],
+                                    [-80.934845, 35.105241],
+                                    [-81.038907, 35.044995],
+                                    [-81.044384, 35.149057],
+                                    [-82.276696, 35.198349],
+                                    [-82.550543, 35.160011],
+                                    [-82.764143, 35.066903],
+                                    [-83.109191, 35.00118],
+                                    [-83.618546, 34.984749],
+                                    [-84.319594, 34.990226],
+                                    [-84.29221, 35.225734],
+                                    [-84.09504, 35.247642],
+                                    [-84.018363, 35.41195],
+                                    [-83.7719, 35.559827],
+                                    [-83.498053, 35.565304],
+                                    [-83.251591, 35.718659],
+                                    [-82.994175, 35.773428],
+                                    [-82.775097, 35.997983],
+                                    [-82.638174, 36.063706],
+                                    [-82.610789, 35.965121],
+                                    [-82.216449, 36.156814],
+                                    [-82.03571, 36.118475],
+                                    [-81.909741, 36.304691],
+                                    [-81.723525, 36.353984],
+                                    [-81.679709, 36.589492],
+                                    [-80.978661, 36.562108]
+                                  ]
+                                ]
+                              }
+                            }
+                          ]
+                        }}
+                      />
+                    </MapContainer>
+                  </Grid>
+                </Grid>
+              }
+            />
           </Grid>
         );
       default:
         return <></>;
     }
   };
-
 
   const errorCases = (value) => {
     if (error !== null) {
@@ -307,24 +457,6 @@ export default function EntityDisplay({
     }
   };
 
-  const attributeNameHelper = (value) => {
-    switch (true) {
-      case value === '':
-        return <Trans>common.errors.mandatory</Trans>;
-      case !isNaN(Number(value[0])):
-        return 'FirstChar should not be a Number';
-      case value.length > 256:
-        setError(true);
-        return 'String too long';
-      case !/^[a-zA-Z0-9-]+$/.test(value):
-        return 'The string contains charts that are not allowed';
-      default:
-        return value.length + '/' + 256;
-    }
-  };
-  const theme = useTheme();
-  const isResponsive = useMediaQuery(theme.breakpoints.down('sm'));
-
   return (
     <div key={msg}>
       <CustomDialogTitle>
@@ -335,61 +467,67 @@ export default function EntityDisplay({
           <Typography sx={{ ml: 2, flex: 1, color: 'black' }} noWrap gutterBottom variant="h6" component="div">
             {title}
           </Typography>
-          <Button autoFocus color="info" onClick={()=>setView(false)}>
+          <Button autoFocus color="info" onClick={() => setView(false)}>
             <Trans>common.editButton</Trans>
           </Button>
         </Toolbar>
       </CustomDialogTitle>
       <DialogContent sx={{ minHeight: '400px' }}>
         <Grid container spacing={1}>
-            <>
-              {attributesMap.map((attribute, i) => (
-                <Grid item xs={12} sm={12} md={12} lg={12} xl={12} key={i} sx={{ marginTop: 1}}>
-                  <Grid
-                    container
-                    spacing={isResponsive ? 1 : 3}
-                    direction="row"
-                    justifyContent="center"
-                    alignItems="center"
-                  >
-                    <Grid item xs={12} sm={12} md={12} lg={12} xl={12}>
-                      <Grid container spacing={3}>
-                        <Grid item xs={12} sm={12} md={12} lg={12} xl={12}>
-                          <Typography variant="h6" gutterBottom component="div" color="primary">
-                          {attribute.name+ ":"}
-                            </Typography>
-                        </Grid>
-                        <Grid item xs={12} sm={12} md={2} lg={2} xl={2}>
-                          <FormControl fullWidth>
-                            <InputLabel id={'rowType' + i} error={errorCases(type.type)}>
-                              <Trans>entity.form.type</Trans>
-                            </InputLabel>
-                            <Select
-                            disabled
-                              color="secondary"
-                              labelId={'rowType' + i}
-                              id={'rowType' + i}
-                              key={'rowType' + i}
-                              value={attribute.type}
-                              variant="outlined"
-                              label={<Trans>entity.form.type</Trans>}
-                              input={<OutlinedInput label="Types" />}
-                            >
-                              {rowTypes.map((thisType) => (
-                                <MenuItem key={thisType.id} value={thisType.id}>
-                                  {thisType.text}
-                                </MenuItem>
-                              ))}
-                            </Select>
-                          </FormControl>
-                        </Grid>
-                        {attributeTypeForm(attribute, i)}
+          <>
+            {attributesMap.map((attribute, i) => (
+              <Grid item xs={12} sm={12} md={12} lg={12} xl={12} key={i} sx={{ marginTop: 1 }}>
+                <Grid
+                  container
+                  spacing={isResponsive ? 1 : 3}
+                  direction="row"
+                  justifyContent="center"
+                  alignItems="center"
+                >
+                  <Grid item xs={12} sm={12} md={12} lg={12} xl={12}>
+                    <Grid container spacing={3}>
+                      <Grid item xs={12} sm={12} md={12} lg={12} xl={12}>
+                        <Typography
+                          variant="h6"
+                          gutterBottom
+                          component="div"
+                          sx={{ color: darken(theme.palette.primary.main, i / 10) }}
+                          key={'title' + i}
+                        >
+                          {attribute.name + ':'}
+                        </Typography>
                       </Grid>
+                      <Grid item xs={12} sm={12} md={2} lg={2} xl={2}>
+                        <FormControl fullWidth>
+                          <InputLabel id={'rowType' + i} error={errorCases(type.type)}>
+                            <Trans>entity.form.type</Trans>
+                          </InputLabel>
+                          <Select
+                            disabled
+                            color="secondary"
+                            labelId={'rowType' + i}
+                            id={'rowType' + i}
+                            key={'rowType' + i}
+                            value={attribute.type}
+                            variant="outlined"
+                            label={<Trans>entity.form.type</Trans>}
+                            input={<OutlinedInput label="Types" />}
+                          >
+                            {rowTypes.map((thisType) => (
+                              <MenuItem key={thisType.id} value={thisType.id}>
+                                {thisType.text}
+                              </MenuItem>
+                            ))}
+                          </Select>
+                        </FormControl>
+                      </Grid>
+                      {attributeTypeForm(attribute, i)}
                     </Grid>
                   </Grid>
                 </Grid>
-              ))}
-            </>
+              </Grid>
+            ))}
+          </>
         </Grid>
       </DialogContent>
     </div>

--- a/src/components/entity/entityDisplay.js
+++ b/src/components/entity/entityDisplay.js
@@ -44,6 +44,7 @@ import { MapContainer, TileLayer, useMap, GeoJSON } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import L from 'leaflet';
 import icon from './map/constants';
+import AddLocationIcon from '@mui/icons-material/AddLocation';
 
 const CustomDialogTitle = styled(AppBar)({
   position: 'relative',
@@ -346,9 +347,9 @@ export default function EntityDisplay({ title, close, setView, data, types }) {
             <DisplayCollapse
               key={'map' + index}
               icon={
-                <AutoFixNormalIcon
+                <AddLocationIcon
                   sx={{ color: theme.palette.getContrastText(theme.palette.primary.main) }}
-                ></AutoFixNormalIcon>
+                ></AddLocationIcon>
               }
               component={
                 <Grid container maxWidth="xl" direction="row" justifyContent="center" alignItems="center">

--- a/src/components/entity/entityDisplay.js
+++ b/src/components/entity/entityDisplay.js
@@ -14,7 +14,6 @@ import FormControl from '@mui/material/FormControl';
 import OutlinedInput from '@mui/material/OutlinedInput';
 import { InputLabel } from '@mui/material';
 import Select from '@mui/material/Select';
-import useNotification from '../shared/messages/alerts';
 import { Trans } from 'react-i18next';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
@@ -26,7 +25,6 @@ import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import { MobileDateTimePicker } from '@mui/x-date-pickers/MobileDateTimePicker';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Switch from '@mui/material/Switch';
-import MapEdit from './map/mapEditor';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
 import { darken } from '@mui/material';
@@ -116,18 +114,7 @@ const DisplayCollapse = ({ component, icon }) => {
   );
 };
 
-export default function EntityDisplay({
-  title,
-  close,
-  setView,
-  env,
-  data,
-  getTheEntities,
-  types,
-  services,
-  GeTenantData,
-  entityEndpoint
-}) {
+export default function EntityDisplay({ title, close, setView, data, types }) {
   const theme = useTheme();
   const isResponsive = useMediaQuery(theme.breakpoints.down('sm'));
   const getAttributesNames = (types) => {
@@ -139,8 +126,6 @@ export default function EntityDisplay({
   };
   //errorLog
   const attributeNames = getAttributesNames(types);
-  const [error, setError] = React.useState(null);
-  const [msg, sendNotification] = useNotification();
 
   const handleClose = () => {
     close(false);
@@ -154,7 +139,6 @@ export default function EntityDisplay({
     { text: <Trans>entity.form.selectType.map</Trans>, id: 'geo:json' }
   ];
   //Type
-  const [type, setType] = React.useState([]);
 
   const [attributesMap, setAttributesMap] = React.useState([]);
   const createAttributesMap = () => {
@@ -196,6 +180,35 @@ export default function EntityDisplay({
         return [47.373878, 8.545094];
     }
   };
+
+  const ChangeView = ({ attribute }) => {
+    const geoJSON = {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          id: 0,
+          properties: {
+            Code: '',
+            Name: ''
+          },
+          geometry: attribute.value
+        }
+      ]
+    };
+    const map = useMap();
+    new L.GeoJSON(geoJSON),
+      {
+        pointToLayer: (latlng) => {
+          return L.marker(latlng.geometry.coordinates, {
+            icon: icon
+          }).addTo(map);
+        }
+      };
+    L.marker(returnCordinates(attribute), { icon }).addTo(map);
+    return null;
+  };
+
   const attributeTypeForm = (attribute, index) => {
     switch (attribute.type !== '' && typeof attribute.type !== 'undefined' && attribute.type !== null) {
       case attribute.type === 'Number':
@@ -252,7 +265,6 @@ export default function EntityDisplay({
                     }
                   }
                 }}
-                error={errorCases(attribute.value)}
                 sx={{
                   width: '100%'
                 }}
@@ -351,6 +363,7 @@ export default function EntityDisplay({
                         attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
                         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
                       />
+                      <ChangeView attribute={attribute} />
                       <GeoJSON
                         key="ID"
                         data={{
@@ -358,76 +371,12 @@ export default function EntityDisplay({
                           features: [
                             {
                               type: 'Feature',
-                              id: '37',
-                              properties: { name: 'North Carolina', density: 198.2 },
-                              geometry: {
-                                type: 'Polygon',
-                                coordinates: [
-                                  [
-                                    [-80.978661, 36.562108],
-                                    [-80.294043, 36.545677],
-                                    [-79.510841, 36.5402],
-                                    [-75.868676, 36.551154],
-                                    [-75.75366, 36.151337],
-                                    [-76.032984, 36.189676],
-                                    [-76.071322, 36.140383],
-                                    [-76.410893, 36.080137],
-                                    [-76.460185, 36.025367],
-                                    [-76.68474, 36.008937],
-                                    [-76.673786, 35.937736],
-                                    [-76.399939, 35.987029],
-                                    [-76.3616, 35.943213],
-                                    [-76.060368, 35.992506],
-                                    [-75.961783, 35.899398],
-                                    [-75.781044, 35.937736],
-                                    [-75.715321, 35.696751],
-                                    [-75.775568, 35.581735],
-                                    [-75.89606, 35.570781],
-                                    [-76.147999, 35.324319],
-                                    [-76.482093, 35.313365],
-                                    [-76.536862, 35.14358],
-                                    [-76.394462, 34.973795],
-                                    [-76.279446, 34.940933],
-                                    [-76.493047, 34.661609],
-                                    [-76.673786, 34.694471],
-                                    [-76.991448, 34.667086],
-                                    [-77.210526, 34.60684],
-                                    [-77.555573, 34.415147],
-                                    [-77.82942, 34.163208],
-                                    [-77.971821, 33.845545],
-                                    [-78.179944, 33.916745],
-                                    [-78.541422, 33.851022],
-                                    [-79.675149, 34.80401],
-                                    [-80.797922, 34.820441],
-                                    [-80.781491, 34.935456],
-                                    [-80.934845, 35.105241],
-                                    [-81.038907, 35.044995],
-                                    [-81.044384, 35.149057],
-                                    [-82.276696, 35.198349],
-                                    [-82.550543, 35.160011],
-                                    [-82.764143, 35.066903],
-                                    [-83.109191, 35.00118],
-                                    [-83.618546, 34.984749],
-                                    [-84.319594, 34.990226],
-                                    [-84.29221, 35.225734],
-                                    [-84.09504, 35.247642],
-                                    [-84.018363, 35.41195],
-                                    [-83.7719, 35.559827],
-                                    [-83.498053, 35.565304],
-                                    [-83.251591, 35.718659],
-                                    [-82.994175, 35.773428],
-                                    [-82.775097, 35.997983],
-                                    [-82.638174, 36.063706],
-                                    [-82.610789, 35.965121],
-                                    [-82.216449, 36.156814],
-                                    [-82.03571, 36.118475],
-                                    [-81.909741, 36.304691],
-                                    [-81.723525, 36.353984],
-                                    [-81.679709, 36.589492],
-                                    [-80.978661, 36.562108]
-                                  ]
-                                ]
-                              }
+                              id: 0,
+                              properties: {
+                                Code: '',
+                                Name: ''
+                              },
+                              geometry: attribute.value
                             }
                           ]
                         }}
@@ -444,21 +393,8 @@ export default function EntityDisplay({
     }
   };
 
-  const errorCases = (value) => {
-    if (error !== null) {
-      switch (true) {
-        case value === '':
-          return true;
-        default:
-          return false;
-      }
-    } else {
-      return false;
-    }
-  };
-
   return (
-    <div key={msg}>
+    <>
       <CustomDialogTitle>
         <Toolbar>
           <IconButton edge="start" onClick={handleClose} aria-label="close">
@@ -476,7 +412,7 @@ export default function EntityDisplay({
         <Grid container spacing={1}>
           <>
             {attributesMap.map((attribute, i) => (
-              <Grid item xs={12} sm={12} md={12} lg={12} xl={12} key={i} sx={{ marginTop: 1 }}>
+              <Grid item xs={12} sm={12} md={12} lg={12} xl={12} key={i} sx={{ marginTop: 2.5 }}>
                 <Grid
                   container
                   spacing={isResponsive ? 1 : 3}
@@ -491,7 +427,7 @@ export default function EntityDisplay({
                           variant="h6"
                           gutterBottom
                           component="div"
-                          sx={{ color: darken(theme.palette.primary.main, i / 10) }}
+                          sx={{ color: darken(theme.palette.primary.main, i / 15) }}
                           key={'title' + i}
                         >
                           {attribute.name + ':'}
@@ -499,7 +435,7 @@ export default function EntityDisplay({
                       </Grid>
                       <Grid item xs={12} sm={12} md={2} lg={2} xl={2}>
                         <FormControl fullWidth>
-                          <InputLabel id={'rowType' + i} error={errorCases(type.type)}>
+                          <InputLabel id={'rowType' + i}>
                             <Trans>entity.form.type</Trans>
                           </InputLabel>
                           <Select
@@ -530,6 +466,6 @@ export default function EntityDisplay({
           </>
         </Grid>
       </DialogContent>
-    </div>
+    </>
   );
 }

--- a/src/components/entity/entityForm.js
+++ b/src/components/entity/entityForm.js
@@ -21,6 +21,7 @@ import { Trans } from 'react-i18next';
 import axios from 'axios';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import dayjs from 'dayjs';
 import InputAdornment from '@mui/material/InputAdornment';
 import 'dayjs/locale/en';
 import 'dayjs/locale/it';
@@ -208,16 +209,15 @@ export default function EntityForm({
                 id={'dateInput' + index}
                 key={'dateInput' + index}
                 showToolbar={false}
-                value={attribute.value === '' ? new Date() : attribute.value}
+                value={attribute.value === '' ? dayjs() : dayjs(attribute.value)}
                 onChange={(newValue) => {
                   const newArray = attributesMap;
                   newArray[Number(index)].value = newValue;
                   setAttributesMap([...[], ...newArray]);
                 }}
-                renderInput={(params) => (
-                  <TextField
-                    {...params}
-                    InputProps={{
+                slotProps={{
+                  field: {
+                    InputProps: {
                       endAdornment: (
                         <InputAdornment position="end" onClick={handlePropagation}>
                           <ClearIcon
@@ -236,13 +236,13 @@ export default function EntityForm({
                           <AccessTimeIcon color="secondary"></AccessTimeIcon>
                         </InputAdornment>
                       )
-                    }}
-                    error={errorCases(attribute.value)}
-                    sx={{
-                      width: '100%'
-                    }}
-                  />
-                )}
+                    }
+                  }
+                }}
+                error={errorCases(attribute.value)}
+                sx={{
+                  width: '100%'
+                }}
               />
             </LocalizationProvider>
           </Grid>
@@ -481,7 +481,7 @@ export default function EntityForm({
     <div key={msg}>
       <CustomDialogTitle>
         <Toolbar>
-          <IconButton edge="start" onClick={()=>view(true)} aria-label="view">
+          <IconButton edge="start" onClick={() => view(true)} aria-label="view">
             <ArrowBackIcon />
           </IconButton>
           <Typography sx={{ ml: 2, flex: 1, color: 'black' }} noWrap gutterBottom variant="h6" component="div">

--- a/src/components/entity/entityForm.js
+++ b/src/components/entity/entityForm.js
@@ -38,6 +38,7 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
 import Autocomplete from '@mui/material/Autocomplete';
 import Chip from '@mui/material/Chip';
+import CloseIcon from '@mui/icons-material/Close';
 
 const CustomDialogTitle = styled(AppBar)({
   position: 'relative',
@@ -481,9 +482,15 @@ export default function EntityForm({
     <div key={msg}>
       <CustomDialogTitle>
         <Toolbar>
-          <IconButton edge="start" onClick={() => view(true)} aria-label="view">
-            <ArrowBackIcon />
-          </IconButton>
+          {action === 'create' ? (
+            <IconButton edge="start" onClick={handleClose} aria-label="close">
+              <CloseIcon />
+            </IconButton>
+          ) : (
+            <IconButton edge="start" onClick={() => view(true)} aria-label="view">
+              <ArrowBackIcon />
+            </IconButton>
+          )}
           <Typography sx={{ ml: 2, flex: 1, color: 'black' }} noWrap gutterBottom variant="h6" component="div">
             {title}
           </Typography>

--- a/src/components/entity/entityTable.js
+++ b/src/components/entity/entityTable.js
@@ -52,7 +52,6 @@ const CustomDialogTitle = styled(AppBar)({
   boxShadow: 'none'
 });
 
-
 const Transition = React.forwardRef(function Transition(props, ref) {
   return <Grow direction="up" ref={ref} {...props} />;
 });
@@ -121,7 +120,7 @@ export default function EntityTable({
 
   const handleCloseEdit = () => {
     setOpenViewOrEdit(false);
-    setView(true)
+    setView(true);
   };
 
   const handleEdit = (data) => {
@@ -562,42 +561,43 @@ export default function EntityTable({
         aria-labelledby="edit"
         aria-describedby="edit"
       >
-      {  (openView&&openViewOrEdit)?
-      <EntityDisplay
-      title={editData.id}
-      close={handleCloseEdit}
-      setView={setView}
-      token={token}
-      env={env}
-      data={editData}
-      GeTenantData={GeTenantData}
-      getTheEntities={getTheEntities}
-      entityEndpoint={entityEndpoint}
-      types={types}
-      services={services}
-    />
-:
-        <EntityForm
-          title={
-            <Trans
-              i18nKey="entity.form.edit"
-              values={{
-                name: editData.id
-              }}
-            />
-          }
-          view={setView}
-          close={handleCloseEdit}
-          action={'modify'}
-          token={token}
-          env={env}
-          data={editData}
-          GeTenantData={GeTenantData}
-          getTheEntities={getTheEntities}
-          entityEndpoint={entityEndpoint}
-          types={types}
-          services={services}
-        />}
+        {openView && openViewOrEdit ? (
+          <EntityDisplay
+            title={editData.id}
+            close={handleCloseEdit}
+            setView={setView}
+            token={token}
+            env={env}
+            data={editData}
+            GeTenantData={GeTenantData}
+            getTheEntities={getTheEntities}
+            entityEndpoint={entityEndpoint}
+            types={types}
+            services={services}
+          />
+        ) : (
+          <EntityForm
+            title={
+              <Trans
+                i18nKey="entity.form.edit"
+                values={{
+                  name: editData.id
+                }}
+              />
+            }
+            view={setView}
+            close={handleCloseEdit}
+            action={'modify'}
+            token={token}
+            env={env}
+            data={editData}
+            GeTenantData={GeTenantData}
+            getTheEntities={getTheEntities}
+            entityEndpoint={entityEndpoint}
+            types={types}
+            services={services}
+          />
+        )}
         <DialogActions></DialogActions>
       </DialogRounded>
       <DialogRounded

--- a/src/components/entity/entityTable.js
+++ b/src/components/entity/entityTable.js
@@ -9,7 +9,6 @@ import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TablePagination from '@mui/material/TablePagination';
 import TableRow from '@mui/material/TableRow';
-import Button from '@mui/material/Button';
 import TableSortLabel from '@mui/material/TableSortLabel';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
@@ -22,7 +21,7 @@ import { visuallyHidden } from '@mui/utils';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import { Trans } from 'react-i18next';
-import EditIcon from '@mui/icons-material/Edit';
+import VisibilityIcon from '@mui/icons-material/Visibility';
 import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import Grow from '@mui/material/Grow';
@@ -236,7 +235,7 @@ export default function EntityTable({
               key={'edit' + thisElement.id}
               onClick={() => handleEdit(thisElement)}
             >
-              <EditIcon />
+              <VisibilityIcon />
             </IconButton>
             <PoliciesOnEntity
               entityPolicies={entityPolicies}
@@ -567,13 +566,8 @@ export default function EntityTable({
             close={handleCloseEdit}
             setView={setView}
             token={token}
-            env={env}
             data={editData}
-            GeTenantData={GeTenantData}
-            getTheEntities={getTheEntities}
-            entityEndpoint={entityEndpoint}
             types={types}
-            services={services}
           />
         ) : (
           <EntityForm

--- a/src/components/entity/entityTable.js
+++ b/src/components/entity/entityTable.js
@@ -9,6 +9,7 @@ import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TablePagination from '@mui/material/TablePagination';
 import TableRow from '@mui/material/TableRow';
+import Button from '@mui/material/Button';
 import TableSortLabel from '@mui/material/TableSortLabel';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
@@ -29,6 +30,7 @@ import dayjs from 'dayjs';
 import * as log from 'loglevel';
 import DeleteDialog from '../shared/messages/cardDelete';
 import EntityForm from './entityForm';
+import EntityDisplay from './entityDisplay';
 import * as tableApi from '../../componentsApi/tableApi';
 import CloseIcon from '@mui/icons-material/Close';
 import axios from 'axios';
@@ -38,17 +40,18 @@ import PoliciesOnEntity from './policyDisplay';
 import DialogContent from '@mui/material/DialogContent';
 import AppBar from '@mui/material/AppBar';
 
+const DialogRounded = styled(Dialog)(() => ({
+  '& .MuiPaper-rounded': {
+    borderRadius: 15
+  }
+}));
+
 const CustomDialogTitle = styled(AppBar)({
   position: 'relative',
   background: 'white',
   boxShadow: 'none'
 });
 
-const DialogRounded = styled(Dialog)(() => ({
-  '& .MuiPaper-rounded': {
-    borderRadius: 15
-  }
-}));
 
 const Transition = React.forwardRef(function Transition(props, ref) {
   return <Grow direction="up" ref={ref} {...props} />;
@@ -112,15 +115,17 @@ export default function EntityTable({
     setOpenDeleteDialog(false);
   };
   // EDIT
-  const [openEdit, setOpenEdit] = React.useState(false);
+  const [openView, setView] = React.useState(true);
+  const [openViewOrEdit, setOpenViewOrEdit] = React.useState(false);
   const [editData, setEditData] = React.useState({});
 
   const handleCloseEdit = () => {
-    setOpenEdit(false);
+    setOpenViewOrEdit(false);
+    setView(true)
   };
 
   const handleEdit = (data) => {
-    setOpenEdit(true);
+    setOpenViewOrEdit(true);
     setEditData(data);
   };
 
@@ -548,7 +553,7 @@ export default function EntityTable({
         </DinamicPaper>
       </Box>
       <DialogRounded
-        open={openEdit}
+        open={openViewOrEdit}
         fullWidth={true}
         maxWidth={'xl'}
         TransitionComponent={Transition}
@@ -557,6 +562,21 @@ export default function EntityTable({
         aria-labelledby="edit"
         aria-describedby="edit"
       >
+      {  (openView&&openViewOrEdit)?
+      <EntityDisplay
+      title={editData.id}
+      close={handleCloseEdit}
+      setView={setView}
+      token={token}
+      env={env}
+      data={editData}
+      GeTenantData={GeTenantData}
+      getTheEntities={getTheEntities}
+      entityEndpoint={entityEndpoint}
+      types={types}
+      services={services}
+    />
+:
         <EntityForm
           title={
             <Trans
@@ -566,6 +586,7 @@ export default function EntityTable({
               }}
             />
           }
+          view={setView}
           close={handleCloseEdit}
           action={'modify'}
           token={token}
@@ -576,7 +597,7 @@ export default function EntityTable({
           entityEndpoint={entityEndpoint}
           types={types}
           services={services}
-        />
+        />}
         <DialogActions></DialogActions>
       </DialogRounded>
       <DialogRounded

--- a/src/components/entity/jsonEditor.js
+++ b/src/components/entity/jsonEditor.js
@@ -62,7 +62,7 @@ export default function JsonEdit({ attribute, attributesMap, setAttributesMap, i
     isJSON(typeof content.json !== 'undefined' ? JSON.stringify(content.json) : content.text)
       ? typeof content.json !== 'undefined'
         ? (newArray[Number(index)].value = content.json)
-        : (newArray[Number(index)].value = content.text)
+        : (newArray[Number(index)].value = JSON.parse(content.text))
       : '';
     setAttributesMap([...[], ...newArray]);
   }, [content]);

--- a/src/components/shared/filters/dateFilter.js
+++ b/src/components/shared/filters/dateFilter.js
@@ -40,7 +40,7 @@ const StyledMenu = styled((props) => (
     color: theme.palette.mode === 'light' ? 'rgb(55, 65, 81)' : theme.palette.grey[300],
     boxShadow: 'none !important',
     '& .MuiMenu-list': {
-      padding: '3% 0'
+      padding: '0% 0'
     },
     '& .MuiMenuItem-root': {
       '& .MuiSvgIcon-root': {
@@ -111,10 +111,9 @@ export default function DateFilter({ status, setstatus, filterValue }) {
                 onChange={(newValue) => {
                   filterValue.set(newValue);
                 }}
-                renderInput={(params) => (
-                  <TextField
-                    {...params}
-                    InputProps={{
+                slotProps={{
+                  field: {
+                    InputProps: {
                       endAdornment: (
                         <InputAdornment position="start" onClick={handlePropagation}>
                           <ClearIcon
@@ -125,9 +124,9 @@ export default function DateFilter({ status, setstatus, filterValue }) {
                           />
                         </InputAdornment>
                       )
-                    }}
-                  />
-                )}
+                    }
+                  }
+                }}
                 sx={{ width: '100%', marginTop: '2%' }}
               />
             </Grow>

--- a/src/components/shared/filters/dateFilter.js
+++ b/src/components/shared/filters/dateFilter.js
@@ -5,7 +5,6 @@ import Menu from '@mui/material/Menu';
 import { MobileDatePicker } from '@mui/x-date-pickers/MobileDatePicker';
 import Grid from '@mui/material/Grid';
 import Grow from '@mui/material/Grow';
-import TextField from '@mui/material/TextField';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import InputAdornment from '@mui/material/InputAdornment';

--- a/src/pages/entityPage.js
+++ b/src/pages/entityPage.js
@@ -255,7 +255,15 @@ export default function EntityPage({ token, graphqlErrors, env, thisTenant, tena
           lg={12}
           xl={12}
           sx={
-            smallDevice ? { width:  (document.getElementById('filterContainer')===null)?300:document.getElementById('filterContainer').clientWidth, 'overflow-x': 'scroll' } : ''
+            smallDevice
+              ? {
+                  width:
+                    document.getElementById('filterContainer') === null
+                      ? 300
+                      : document.getElementById('filterContainer').clientWidth,
+                  'overflow-x': 'scroll'
+                }
+              : ''
           }
         >
           <EntityFilters services={services} data={entities} mapper={filterMapper} types={types} />

--- a/src/pages/entityPage.js
+++ b/src/pages/entityPage.js
@@ -255,7 +255,7 @@ export default function EntityPage({ token, graphqlErrors, env, thisTenant, tena
           lg={12}
           xl={12}
           sx={
-            smallDevice ? { width: document.getElementById('filterContainer').clientWidth, 'overflow-x': 'scroll' } : ''
+            smallDevice ? { width:  (document.getElementById('filterContainer')===null)?300:document.getElementById('filterContainer').clientWidth, 'overflow-x': 'scroll' } : ''
           }
         >
           <EntityFilters services={services} data={entities} mapper={filterMapper} types={types} />

--- a/src/pages/policyPage.js
+++ b/src/pages/policyPage.js
@@ -275,7 +275,13 @@ export default function PolicyPage({ getTenants, tenantValues, thisTenant, graph
             xl={12}
             sx={
               smallDevice
-                ? { width: (document.getElementById('filterContainer')===null)?300:document.getElementById('filterContainer').clientWidth, 'overflow-x': 'scroll' }
+                ? {
+                    width:
+                      document.getElementById('filterContainer') === null
+                        ? 300
+                        : document.getElementById('filterContainer').clientWidth,
+                    'overflow-x': 'scroll'
+                  }
                 : ''
             }
           >

--- a/src/pages/policyPage.js
+++ b/src/pages/policyPage.js
@@ -275,7 +275,7 @@ export default function PolicyPage({ getTenants, tenantValues, thisTenant, graph
             xl={12}
             sx={
               smallDevice
-                ? { width: document.getElementById('filterContainer').clientWidth, 'overflow-x': 'scroll' }
+                ? { width: (document.getElementById('filterContainer')===null)?300:document.getElementById('filterContainer').clientWidth, 'overflow-x': 'scroll' }
                 : ''
             }
           >

--- a/src/translations/translationEN.json
+++ b/src/translations/translationEN.json
@@ -175,6 +175,7 @@
     "deleteText": "Are you really sure about deleting:",
     "deleteTextTitle": "Are you sure?",
     "saveButton": "SAVE",
+    "editButton": "EDIT",
     "deleteButton": "DELETE",
     "userPopup": {
       "settings": "settings"

--- a/src/translations/translationIT.json
+++ b/src/translations/translationIT.json
@@ -175,6 +175,7 @@
     "deleteText": "Sei davvero sicuro di voler eliminare:",
     "deleteTextTitle": "Sei sicuro di procedere?",
     "saveButton": "SALVA",
+    "editButton": "EDITA",
     "deleteButton": "ELIMINA",
     "userPopup": {
       "settings": "Impostazioni"


### PR DESCRIPTION
## Proposed changes

Create a better and more intuitive visualization for the entity properties with the possibility to switch to the edit

## Types of changes

What types of changes does your code introduce to the project: _Put
an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation (improve documentation)
- [ ] Continuous Integration (functionality that improve automation or testing)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)

## Checklist



- [x] I have read the [CONTRIBUTING][contrib] doc
- [x] I have signed the [Contributor License Agreement][cla]
- [x] I have updated the [RELEASE NOTES][release]
- [ ] I have added tests that prove my fix is effective or that my
      feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in
      downstream modules

## Further comments

Of course the button previusly dedicated to the edit is now for the display (the icon is changed tho)



[cla]: https://raw.githubusercontent.com/orchestracities/auth-management-ui/master/individual_cla.pdf
    "Martel Open Source Software Individual Contributor License Agreement"
[contrib]: https://github.com/orchestracities/auth-management-ui/blob/master/CONTRIBUTING.md
    "Contributing to auth-management-ui"
[release]: https://github.com/orchestracities/auth-management-ui/blob/master/RELEASE_NOTES.md
    "auth-management-ui Release Notes"
